### PR TITLE
Fix uninitialized constant error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.1.10 2021-02-19
+### Fixed
+
+ Add NxtStateMachine::Errors::Error because when including NxtStateMachine::ActiveRecord in a nested
+ class the following error was raised:
+  ```
+    uninitialized constant NxtStateMachine::Errors::Error
+  ```
+
 # v0.1.9 2020-09-23
 
 ### Added 

--- a/lib/nxt_state_machine/errors/error.rb
+++ b/lib/nxt_state_machine/errors/error.rb
@@ -1,3 +1,8 @@
 module NxtStateMachine
   Error = Class.new(StandardError)
+
+  module Errors
+    class Error < StandardError
+    end
+  end
 end

--- a/lib/nxt_state_machine/version.rb
+++ b/lib/nxt_state_machine/version.rb
@@ -1,3 +1,3 @@
 module NxtStateMachine
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end


### PR DESCRIPTION
When attempting to include `NxtStateMachine::ActiveRecord` in `Insurance::ChangeRequest` the following error was raised:

```bash
uninitialized constant NxtStateMachine::Errors::Error
```
Not sure how this worked for other projects as that class was never defined in this gem.  Anyways, I defined it and it solved the error I was getting.

