### PR TITLE
- Adding new event  'any_state_except'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.1.11 2023-04-20
+
+### Added
+
+- new event 'any_state_except'
+
+[Compare v0.1.10...v0.1.11](https://github.com/nxt-insurance/nxt_state_machine/pull/82)
+
 # v0.1.10 2021-07-19
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_state_machine (0.1.10)
+    nxt_state_machine (0.1.11)
       activesupport
       nxt_registry (~> 0.3.0)
 

--- a/lib/nxt_state_machine/event.rb
+++ b/lib/nxt_state_machine/event.rb
@@ -23,6 +23,7 @@ module NxtStateMachine
              :on_error,
              :on_error!,
              :any_state,
+             :any_state_except,
              :all_states,
              :all_states_except,
              :defuse,

--- a/lib/nxt_state_machine/state_machine.rb
+++ b/lib/nxt_state_machine/state_machine.rb
@@ -75,10 +75,7 @@ module NxtStateMachine
       states.values.map(&:enum)
     end
 
-    def any_state_except(*excluded)
-      any_state - excluded
-    end
-
+    alias_method :all_states_except, :any_state_except
     alias_method :all_states, :any_state
 
     def all_states_except(*excluded)

--- a/lib/nxt_state_machine/state_machine.rb
+++ b/lib/nxt_state_machine/state_machine.rb
@@ -75,6 +75,10 @@ module NxtStateMachine
       states.values.map(&:enum)
     end
 
+    def any_state_except(*excluded)
+      any_state - excluded
+    end
+
     alias_method :all_states, :any_state
 
     def all_states_except(*excluded)

--- a/lib/nxt_state_machine/state_machine.rb
+++ b/lib/nxt_state_machine/state_machine.rb
@@ -82,6 +82,10 @@ module NxtStateMachine
       all_states - excluded
     end
 
+    def any_state_except(*excluded)
+      any_state - excluded
+    end
+
     def event(name, **options, &block)
       name = name.to_sym
       event = Event.new(name, self, **options, &block)

--- a/lib/nxt_state_machine/version.rb
+++ b/lib/nxt_state_machine/version.rb
@@ -1,3 +1,3 @@
 module NxtStateMachine
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end


### PR DESCRIPTION
### References
https://hellogetsafe.atlassian.net/browse/PLAT-1983

### What is the goal? How is it being implemented?
Adding a new event 'any_state_except' to allow excluding states while using 'any_state' event

### How can it be tested?
Claims Manager
Automated tests

### How can it be monitored?
Standard monitoring.

### How is it going to be deployed?
Standard deployment.
