### PR TITLE
Expose list of event methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.1.11 2023-06-29
+
+### Added
+- Added `state_machine.event_methods`
+
+[Compare v0.1.10...v0.1.11](https://github.com/nxt-insurance/nxt_state_machine/compare/v0.1.10...v0.1.11)
+
 # v0.1.10 2021-07-19
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_state_machine (0.1.10)
+    nxt_state_machine (0.1.11)
       activesupport
       nxt_registry (~> 0.3.0)
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,14 @@ class Article < ApplicationRecord
 end
 ```
 
-You can also navigate between states 
+You can retrieve a list of states using the `states` method:
+
+```rb
+states = Article.state_machine.states # returns a NxtStateMachine::StateRegistry instance
+states.keys # ["draft", "written", "submitted", "approved", "published", "rejected", "deleted"]
+```
+
+You can also navigate between states:
 
 ```ruby
 state.next # will give you the next state in the order they have been registered
@@ -191,6 +198,7 @@ state.last? # last registered state?
 state.index # gives you the index of the state in the registry 
 # You can also set indexes manually by passing in indexes when defining states. Make sure they are in order! 
 ```
+
 
 ### Events
 
@@ -241,14 +249,26 @@ article.approve(approved_at: Time.current)
 article.approve!(approved_at: Time.current)
 ```
 
-**NOTE:** Transitions run in transactions that acquire a lock to prevent concurrency issues per default. 
-Transactions will be rolled back in case of an exception or if your target cannot be saved due to validation errors. 
+> **Note**:
+> 
+> By default, transitions run in transactions that acquire a lock to prevent concurrency issues. 
+Transactions will be rolled back if an exception occurs or if your target cannot be saved due to validation errors. 
 The state is set back to the state before the transition! If you try to transition on records with unpersisted changes
 you will get a `RuntimeError: Locking a record with unpersisted changes is not supported.` error saying something
 like `Use :save to persist the changes, or :reload to discard them explicitly.` since it's not possible to acquire a 
-lock on modified records. You can also switch of locking and transactions for events by passing in the `lock_transitions: false` 
+lock on modified records. 
+> 
+> You can switch off locking and transactions for events by passing in the `lock_transitions: false` 
 option when defining an event or globally on the state machine with the `lock_transitions: false` option. Currently 
 there is no option to toggle locking at runtime.   
+
+
+You can retrieve a list of event methods with `event_methods`:
+
+```rb
+Article.state_machine.event_methods 
+# => [:write, :submit, :approve, :publish, :reject, :delete, :write!, :submit!, :approve!, :publish!, :reject!, :delete!]
+```
 
 ### Transitions
 

--- a/lib/nxt_state_machine/state_machine.rb
+++ b/lib/nxt_state_machine/state_machine.rb
@@ -75,6 +75,13 @@ module NxtStateMachine
       states.values.map(&:enum)
     end
 
+    def event_methods
+      event_names = events.keys
+      event_names_with_bang = event_names.map { |e| e + '!' }
+
+      (event_names + event_names_with_bang).map(&:to_sym)
+    end
+
     alias_method :all_states, :any_state
 
     def all_states_except(*excluded)

--- a/lib/nxt_state_machine/version.rb
+++ b/lib/nxt_state_machine/version.rb
@@ -1,3 +1,3 @@
 module NxtStateMachine
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end

--- a/spec/nxt_state_machine_spec.rb
+++ b/spec/nxt_state_machine_spec.rb
@@ -149,16 +149,16 @@ RSpec.describe NxtStateMachine do
       it 'returns all event names and bang versions' do
         expect(subject.event_methods).to match_array([
           :write,
-          :write!,
           :submit,
-          :submit!,
           :approve,
-          :approve!,
           :publish,
-          :publish!,
           :reject,
-          :reject!,
           :delete,
+          :write!,
+          :submit!,
+          :approve!,
+          :publish!,
+          :reject!,
           :delete!,
         ])
       end

--- a/spec/nxt_state_machine_spec.rb
+++ b/spec/nxt_state_machine_spec.rb
@@ -126,6 +126,45 @@ RSpec.describe NxtStateMachine do
     end
   end
 
+  describe '#state_machine' do
+    subject do
+      ArticleWorkflow.new(article, test: 'options').state_machine
+    end
+
+    describe '#states' do
+      it 'returns all states' do
+        expect(subject.states.keys).to match_array(%w[
+          draft
+          written
+          submitted
+          approved
+          published
+          rejected
+          deleted
+        ])
+      end
+    end
+
+    describe '#event_methods' do
+      it 'returns all event names and bang versions' do
+        expect(subject.event_methods).to match_array([
+          :write,
+          :write!,
+          :submit,
+          :submit!,
+          :approve,
+          :approve!,
+          :publish,
+          :publish!,
+          :reject,
+          :reject!,
+          :delete,
+          :delete!,
+        ])
+      end
+    end
+  end
+
   describe 'callbacks' do
     let(:state_machine_class) do
       Class.new do


### PR DESCRIPTION
We often add the `event_methods` helper in our workflow classes, but it should be exposed directly by the state machine. This PR implements that.

[BE-42][]

[BE-42]: https://hellogetsafe.atlassian.net/browse/BE-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ